### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cd first-mlops-project
 
 ```
 python3 -m venv .mlops
-source .mlops/bin/activate
+source .mlops/bin/activate    # For macOs
+source .mlops/Scripts/activate   # For windows
 ```
 
 ### 3. Install Dependencies

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ kubectl apply -f diabetes-prediction-model-deployment.yaml
 ## Output
 ![image](https://github.com/user-attachments/assets/e80359fb-1243-4ca7-84c8-9b92c80a18c0)
 
+After changing the parameters 
+![image](https://github.com/user-attachments/assets/5159037f-1ef6-4e67-a9ad-985c812b53e3)
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ docker run -p 8000:8000 diabetes-prediction-model
 kubectl apply -f diabetes-prediction-model-deployment.yaml
 ```
 
-🙌 Credits
+## Output
+![image](https://github.com/user-attachments/assets/e80359fb-1243-4ca7-84c8-9b92c80a18c0)
 
-Created by `ABHISHEK VEERAMALLA`
+-- port forwarding 
+![image](https://github.com/user-attachments/assets/a0b63d1e-e2f4-4a71-b707-798a2938aab2)
 
-Subscribe for more DevOps + MLOps content on the YouTube Channel - `Abhishek.Veeramalla`
+
+
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ docker run -p 8000:8000 diabetes-prediction-model
 kubectl apply -f diabetes-prediction-model-deployment.yaml
 ```
 
+## port forwarding 
+![image](https://github.com/user-attachments/assets/a0b63d1e-e2f4-4a71-b707-798a2938aab2)
+
 ## Output
 ![image](https://github.com/user-attachments/assets/e80359fb-1243-4ca7-84c8-9b92c80a18c0)
 
--- port forwarding 
-![image](https://github.com/user-attachments/assets/a0b63d1e-e2f4-4a71-b707-798a2938aab2)
+
 
 
 


### PR DESCRIPTION
For windows we can use the command to activate the venv ( .venv/Scripts/activate) . Happy to help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify virtual environment activation steps for both macOS and Windows users.
  * Added new sections on port forwarding and output with illustrative images.
  * Removed the credits and subscription call-to-action sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->